### PR TITLE
Fix: wrong number of arguments to get method for redis

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -273,7 +273,7 @@ module ActiveSupport
 
         def read_entry(key, options)
           failsafe(:read_entry) do
-            entry = with { |c| c.get key, options }
+            entry = with { |c| c.get key }
             return unless entry
             entry.is_a?(Entry) ? entry : Entry.new(entry)
           end


### PR DESCRIPTION
we are passing extra options to redis get method, But get will expect only one argument as key. So removing extra options from code.